### PR TITLE
Fix text index not working when used with another option like skip or limit

### DIFF
--- a/test/text-search.test.js
+++ b/test/text-search.test.js
@@ -93,7 +93,7 @@ describe('Text Search (service delegate)', function () {
 
     it('should add a $meta option to return text search score', function () {
       var options = extendOptions({ skip: 10 })
-      options.should.eql({ skip: 10, score: { $meta: 'textScore' } })
+      options.should.eql({ skip: 10, fields: { score: { $meta: 'textScore' } } })
     })
 
   })

--- a/text-search.js
+++ b/text-search.js
@@ -71,5 +71,5 @@ function buildSearchQuery(searchString, query) {
 }
 
 function extendOptions(options) {
-  return _.extend(options, { score: { $meta: 'textScore' } })
+  return _.extend(options, { fields: { score: { $meta: 'textScore' } } })
 }


### PR DESCRIPTION
Text index score is not pulled through if you also specify another option. 

This PR fixes that.
