### PR TITLE
fix(upgrade): Prevents textScore being added if there are no search terms as required per mongo 4.4

### DIFF
--- a/text-search.js
+++ b/text-search.js
@@ -38,7 +38,7 @@ function textSearch(service) {
       options = {}
     }
 
-    options = extendOptions(options)
+    options = extendOptions(options, searchTerms)
     var qry = buildSearchQuery(searchTerms, query)
     service.count(qry, function (err, count) {
       if (err) return cb(err)
@@ -70,7 +70,8 @@ function buildSearchQuery(searchString, query) {
   return query
 }
 
-function extendOptions(options) {
+function extendOptions(options, searchTerms) {
+  if (searchTerms === '') return options
   options.fields = _.extend({}, options.fields, { score: { $meta: 'textScore' } })
   return options
 }


### PR DESCRIPTION
As per 4.4 release notes:
https://docs.mongodb.com/manual/release-notes/4.4/
"You must specify the $text operator in the query predicate to use { $meta: "textScore" }."

Currently we always include { $meta: "textScore" }, this means that when we don't have "$text" it fails. This change makes it so that { $meta: "textScore" } is only included if the same condition is met for when we add "$text."

Backwards Compatibility Loom (Tested on 4.0.3):
- Search works
- Offers don't break on load
https://www.loom.com/share/3e3491b1a73949edb69e217ad4c16594?from_recorder=1&focus_title=1