### PR TITLE
feat: remove lodash

### DIFF
--- a/text-search.js
+++ b/text-search.js
@@ -5,8 +5,6 @@ module.exports.buildSearchQuery = buildSearchQuery
 // Expose the extend options function for testing
 module.exports.extendOptions = extendOptions
 
-var _ = require('lodash')
-
 /*
  * The textSearch function returns a 'search' endpoint that can be used to search
  * the textIndex, e.g.:
@@ -72,6 +70,6 @@ function buildSearchQuery(searchString, query) {
 
 function extendOptions(options, searchTerms) {
   if (searchTerms === '') return options
-  options.fields = _.extend({}, options.fields, { score: { $meta: 'textScore' } })
+  options.fields = Object.assign({}, options.fields, { score: { $meta: 'textScore' } })
   return options
 }


### PR DESCRIPTION
This does not need to be a dependency for a single function.
Support for `Object.assign` has been around since Node v4 so I'd say it
is pretty safe to drop support for versions before then.

(please see #PR PENDING# for the actual removal from package.json